### PR TITLE
upgrades for rasterio 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ install:
   - "pip wheel -r requirements.txt"
   # Actually install our dependencies now, this will pull from the directory
   # that the first command placed the Wheels into.
-  - "pip install -r requirements.txt"
+  - "pip install --no-binary rasterio -r requirements.txt"
   - "pip install coveralls"
   - "pip install -e .[test]"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-rasterio
+rasterio==1.0a8
 mercantile
 mbutil

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with codecs_open('README.rst', encoding='utf-8') as f:
 
 
 setup(name='untiler',
-      version='0.1.0',
+      version='0.2.0',
       description=u"Combine image tiles into composite TIFs",
       long_description=long_description,
       classifiers=[],

--- a/tests/test_untiler_funcs.py
+++ b/tests/test_untiler_funcs.py
@@ -209,8 +209,7 @@ def test_upsampling():
 
     test = np.zeros((3, rShape, rShape))
 
-    with rasterio.drivers():
-        outputUp = untiler.upsample(test, rUp, frFaux, toFaux)
+    outputUp = untiler.upsample(test, rUp, frFaux, toFaux)
 
     assert outputUp.shape == (3, rUp * rShape, rUp * rShape)
 


### PR DESCRIPTION
For rasterio1.0, we needed to

* remove `rasterio.drivers` context manager
* rename the `Resampling` enum

cc @dnomadb 