### PR TITLE
Fix tests, update Rasterio

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ env:
     - PIP_FIND_LINKS=file://$HOME/.cache/pip/wheels
 
 python:
-  - "2.7"
   - "3.6"
+  - "3.7"
 
 before_install:
   - pip install -U pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,22 @@ env:
     - PIP_WHEEL_DIR=$HOME/.cache/pip/wheels
     - PIP_FIND_LINKS=file://$HOME/.cache/pip/wheels
 
-python:
-  - "3.6"
-  - "3.7"
+jobs:
+  include:
+    - python: "3.6"
+      env:
+        GDALVERSION="2.3.3"
+    - python: "3.7"
+        GDALVERSION="2.4.4"
 
+addons:
+  apt:
+    packages:
+      - libhdf5-serial-dev
+      - libgdal-dev
+      - libatlas-dev
+      - libatlas-base-dev
+      - gfortran
 
 before_install:
   - pip install -U pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ python:
 addons:
   apt:
     packages:
-    - libgdal1h
+    - libgdal1i
     - gdal-bin
     - libgdal-dev
     - libatlas-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
   - "pip wheel -r requirements.txt"
   # Actually install our dependencies now, this will pull from the directory
   # that the first command placed the Wheels into.
-  - "pip install --no-binary rasterio -r requirements.txt"
+  - "pip install -r requirements.txt"
   - "pip install coveralls"
   - "pip install -e .[test]"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,54 +3,28 @@ language: python
 sudo: false
 
 cache:
-  # Apparently if you override the install command that silently disables the
-  # cache: pip support. This is less than ideal and I've opened up
-  # travis-ci/travis-ci#3239 to hopefully get that addressed. For now I'll
-  # manually add the pip cache directory to the build cache.
   directories:
     - ~/.cache/pip
 
 env:
   global:
-    # These two environment variables could be set by Travis itself, or Travis
-    # could configure itself in /etc/, ~/, or inside of the virtual
-    # environments. In any case if these two values get configured then end
-    # users only need to enable the pip cache and manually run pip wheel before
-    # running pip install.
     - PIP_WHEEL_DIR=$HOME/.cache/pip/wheels
     - PIP_FIND_LINKS=file://$HOME/.cache/pip/wheels
 
-jobs:
-  include:
-    - python: "3.6"
-      env:
-        GDALVERSION="2.3.3"
-    - python: "3.7"
-        GDALVERSION="2.4.4"
-
-addons:
-  apt:
-    packages:
-      - libhdf5-serial-dev
-      - libgdal-dev
-      - libatlas-dev
-      - libatlas-base-dev
-      - gfortran
+python:
+  - "2.7"
+  - "3.6"
 
 before_install:
   - pip install -U pip
-  - pip install wheel
+  - pip install -r requirements-dev.txt
 
 install:
-  - "pip wheel -r requirements.txt"
-  # Actually install our dependencies now, this will pull from the directory
-  # that the first command placed the Wheels into.
-  - "pip install -r requirements.txt"
-  - "pip install coveralls"
-  - "pip install -e .[test]"
+  - pip install -e .[test]
 
 script:
-  - py.test --cov untiler --cov-report term-missing
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then pre-commit run --all-files; fi
+  - python -m pytest --cov untiler --cov-report term-missing
 
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ install:
   - pip install -e .[test]
 
 script:
-  - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then pre-commit run --all-files; fi
   - python -m pytest --cov untiler --cov-report term-missing
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ python:
 
 before_install:
   - pip install -U pip
-  - pip install -r requirements-dev.txt
+  - pip install -r requirements.txt
 
 install:
   - pip install -e .[test]

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ env:
     - PIP_FIND_LINKS=file://$HOME/.cache/pip/wheels
 
 python:
-  - "2.7"
   - "3.6"
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,19 +22,8 @@ env:
 
 python:
   - "3.6"
+  - "3.7"
 
-addons:
-  apt:
-    packages:
-    - libgdal1i
-    - gdal-bin
-    - libgdal-dev
-    - libatlas-dev
-    - libatlas-base-dev
-    - liblapack-dev
-    - gfortran
-    - libgmp-dev
-    - libmpfr-dev
 
 before_install:
   - pip install -U pip

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-rasterio==1.0a8
+rasterio==1.1.2
 mercantile
 mbutil

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,7 @@ import mercantile
 import numpy as np
 import pytest
 import rasterio as rio
-
+import sqlite3
 from untiler.scripts.cli import cli
 
 
@@ -88,7 +88,8 @@ def test_cli_streamdir_mixed_ok_poo():
         tmp = testtiles.path
         runner = CliRunner()
         result = runner.invoke(cli, ['streamdir', tmp, tmp, '-c', '14', '-t', 'poo/{z}/{z}/{z}.jpg'])
-        assert result.exit_code == -1
+
+        assert result.exc_info[0] == ValueError
 
 
 def test_cli_baddir_fails():
@@ -154,4 +155,5 @@ def test_extract_mbtiles_fails():
         result = runner.invoke(cli, [
             'streammbtiles', testmbtiles, testpath, '-z', '16', '-x', '-s',
             '{z}-{x}-{y}-mbtiles.tif', '--co', 'compress=lzw'])
-        assert result.exit_code == -1
+
+        assert result.exc_info[0] == sqlite3.OperationalError

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -148,7 +148,7 @@ def test_extract_mbtiles():
             with rio.open(o) as src:
                 checksums.append([src.checksum(i) for i in src.indexes])
 
-        assert checksums == expected_checksums
+        assert sorted(checksums) == sorted(expected_checksums)
 
 
 def test_extract_mbtiles_fails():
@@ -156,6 +156,7 @@ def test_extract_mbtiles_fails():
         testpath = tt.path
         testmbtiles = os.path.join(os.path.dirname(__file__), 'fixtures/bad.mbtiles')
         runner = CliRunner()
+
         result = runner.invoke(cli, [
             'streammbtiles', testmbtiles, testpath, '-z', '16', '-x', '-s',
             '{z}-{x}-{y}-mbtiles.tif', '--co', 'compress=lzw'])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -140,11 +140,15 @@ def test_extract_mbtiles():
             'streammbtiles', testmbtiles, testpath, '-z', '16', '-x', '-s',
             '{z}-{x}-{y}-mbtiles.tif', '--co', 'compress=lzw'])
         assert result.exit_code == 0
+
         expected_checksums = [[13858, 8288, 51489, 31223], [17927, 52775, 411, 9217]]
-        for o, c in zip(result.output.rstrip().split('\n'), expected_checksums):
+        checksums = []
+
+        for o in result.output.rstrip().split('\n'):
             with rio.open(o) as src:
-                checksums = [src.checksum(i) for i in src.indexes]
-                assert checksums == c
+                checksums.append([src.checksum(i) for i in src.indexes])
+
+        assert checksums == expected_checksums
 
 
 def test_extract_mbtiles_fails():

--- a/tests/test_untiler_funcs.py
+++ b/tests/test_untiler_funcs.py
@@ -105,7 +105,7 @@ def expectedTileList():
         return np.array(json.load(ofile))
 
 def test_parse_tiles(inputTilenames, expectedTileList):
-    matchTemplate = '3857_9_83_202_20130517_242834/jpg/\d+/\d+/\d+.jpg'
+    matchTemplate = r'3857_9_83_202_20130517_242834/jpg/\d+/\d+/\d+.jpg'
 
     tiler = tile_utils.TileUtils()
 

--- a/untiler/__init__.py
+++ b/untiler/__init__.py
@@ -222,7 +222,7 @@ def stream_dir(inputDir, outputDir, compositezoom, maxzoom, logdir, read_templat
 
     allFiles = tiler.search_dir(inputDir)
 
-    template, readTemplate, separator = tile_utils.parse_template(r"%s/%s" % (inputDir, read_template))
+    template, readTemplate, separator = tile_utils.parse_template("%s/%s" % (inputDir, read_template))
 
     allTiles = np.array([i for i in tiler.get_tiles(allFiles, template, separator)])
 

--- a/untiler/__init__.py
+++ b/untiler/__init__.py
@@ -222,7 +222,7 @@ def stream_dir(inputDir, outputDir, compositezoom, maxzoom, logdir, read_templat
 
     allFiles = tiler.search_dir(inputDir)
 
-    template, readTemplate, separator = tile_utils.parse_template("%s/%s" % (inputDir, read_template))
+    template, readTemplate, separator = tile_utils.parse_template(r"%s/%s" % (inputDir, read_template))
 
     allTiles = np.array([i for i in tiler.get_tiles(allFiles, template, separator)])
 

--- a/untiler/scripts/tile_utils.py
+++ b/untiler/scripts/tile_utils.py
@@ -148,7 +148,7 @@ def parse_template(template):
         if len(separator) != 2 or separator[0] != separator[1]:
             raise ValueError('Too many / not matching separators!')
     
-        return valPattern.sub(r"\d+", template), valPattern.sub(r"%s", template), separator[0]
+        return valPattern.sub(r"\d+", template), valPattern.sub("%s", template), separator[0]
     else:
         raise ValueError('Invalid template "%s"' % (template))
 

--- a/untiler/scripts/tile_utils.py
+++ b/untiler/scripts/tile_utils.py
@@ -148,7 +148,7 @@ def parse_template(template):
         if len(separator) != 2 or separator[0] != separator[1]:
             raise ValueError('Too many / not matching separators!')
     
-        return valPattern.sub('\d+', template), valPattern.sub('%s', template), separator[0]
+        return valPattern.sub(r"\d+", template), valPattern.sub(r"%s", template), separator[0]
     else:
         raise ValueError('Invalid template "%s"' % (template))
 

--- a/untiler/scripts/tile_utils.py
+++ b/untiler/scripts/tile_utils.py
@@ -148,7 +148,7 @@ def parse_template(template):
         if len(separator) != 2 or separator[0] != separator[1]:
             raise ValueError('Too many / not matching separators!')
     
-        return valPattern.sub(r"\d+", template), valPattern.sub("%s", template), separator[0]
+        return valPattern.sub(r"\\d+", template), valPattern.sub("%s", template), separator[0]
     else:
         raise ValueError('Invalid template "%s"' % (template))
 


### PR DESCRIPTION
Changes:

- Replaces libgdal1h with libgdal1i in the Travis build
- Updates rasterio from 1.0a8 to 1.1.2 
- Instead of checking exit codes, tests now explicitly check for the type of exception raised
- Fixes #24 
- Drops Python 2.7 Travis builds 